### PR TITLE
Fixes porting of symbols with PySide6/QT6

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -112,7 +112,15 @@ class BindiffViewerDialog(QDialog):
 
 		menu = QMenu(self.match_view)
 		menu.addAction("Port symbols", action_port_symbols)
-		menu.exec_(self.match_view.mapToGlobal(pos))
+
+		mv = self.match_view.mapToGlobal(pos)
+
+		try:
+			import PySide6
+
+			menu.exec(mv)
+		except ImportError:
+			menu.exec_(mv)
 
 	def port_symbols(self, i):
 		if self.role == None:


### PR DESCRIPTION
See: https://bugreports.qt.io/browse/PYSIDE-1625.

Maintains backwards compatibility. Depends on: https://github.com/PistonMiner/binaryninja-bindiff-viewer/pull/1.